### PR TITLE
DEVSUP-148 increase channel list limit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ async function getChannelId(
   slackInstance: WebClient
 ): Promise<string | undefined> {
   try {
-    const result = await slackInstance.conversations.list()
+    const result = await slackInstance.conversations.list({ limit: 400} )
 
     const channel = result.channels?.find(c => c.name === channelName)
     if (channel) {


### PR DESCRIPTION
By default only 100 channels are returned. This change is to increase the limit to 400.  